### PR TITLE
Make it so lmdb is only imported if it's used

### DIFF
--- a/code/data/util.py
+++ b/code/data/util.py
@@ -3,7 +3,6 @@ import math
 import pickle
 import random
 import numpy as np
-import lmdb
 import torch
 import cv2
 import logging
@@ -32,6 +31,7 @@ def _get_paths_from_images(path):
 
 
 def _get_paths_from_lmdb(dataroot):
+    import lmdb
     env = lmdb.open(dataroot, readonly=True, lock=False, readahead=False, meminit=False)
     keys_cache_file = os.path.join(dataroot, '_keys_cache.p')
     logger = logging.getLogger('base')


### PR DESCRIPTION
If lmdb isn't used, do not require the user to have it installed.
Otherwise they will see an error similar to this:
![image](https://user-images.githubusercontent.com/24628639/87835206-d5f25480-c862-11ea-8ed5-4f2edb3b3adc.png)


lmdb requires cpython which requires MS Visual Studio to be installed, if you don't have it installed pip will throw you an error like this:

![image](https://user-images.githubusercontent.com/24628639/87835109-988dc700-c862-11ea-8ea4-9934ecf230d1.png)

As it's not often used, move it to where it's used so it will only ask for it if the user needs it.
